### PR TITLE
fix: Added [e] index boundaries

### DIFF
--- a/test/utils.test.tsx
+++ b/test/utils.test.tsx
@@ -1,0 +1,35 @@
+import {
+  buildHighlightMap,
+  getHighlightedOptions,
+  splitByBreakOpportunities,
+} from '../src/utils.js'
+import { describe, expect, it } from 'vitest'
+
+function buildHighlightIndices(content: string) {
+  const highlights = getHighlightedOptions(content)
+  const { words } = splitByBreakOpportunities(content, 'normal')
+  return buildHighlightMap(highlights, words)
+}
+
+describe('highlight tag handling', () => {
+  it('should not throw on dangling [s] without [e]', () => {
+    const input = 'Hello [s]world'
+    expect(() => buildHighlightIndices(input)).not.toThrow()
+  })
+
+  it('should not throw on trailing [e]', () => {
+    const input = 'Hello world[e]'
+    expect(() => buildHighlightIndices(input)).not.toThrow()
+  })
+
+  it('should not throw on blank styled span', () => {
+    const input = '[s][e]'
+    expect(() => buildHighlightIndices(input)).not.toThrow()
+  })
+
+  it('should produce balanced highlight map', () => {
+    const input = 'foo [s]bar[e] baz'
+    const map = buildHighlightIndices(input)
+    expect(Object.keys(map).length).toBeGreaterThan(0)
+  })
+})


### PR DESCRIPTION
This PR fixes an issue where unmatched or empty [s]…[e] highlight tags could cause RangeError or TypeError in getHighlightedOptions → buildHighlightMap.

Problem

* Input like "[s][e]" (no visible characters) produced an empty words array, causing words[0].trim() to throw.
* Input ending with [e] caused end to equal the total length, so charToWord threw an out-of-bounds error.

Fix

* In getHighlightedOptions, clamp end indices and skip pushing ranges when visible === 0.
* In buildHighlightMap, short-circuit if words.length === 0.
* Added clamping in charToWord for defensive safety.

Result

* No more crashes for blank or dangling highlight spans.
* Normal balanced cases ([s]foo[e]) continue to work as expected.
* Tests added for blank, trailing [e], and dangling [s] inputs.